### PR TITLE
chore(repo): Fix actions cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v3
-      - name: Install cypress dependencies
+      - name: Install Cypress dependencies
         run: sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -42,17 +42,17 @@ jobs:
         run: npm ci
       - name: Build
         run: npx nx affected --target=build
-      - name: Lint Core Files
+      - name: Lint core files
         run: npm run lint-core
-      - name: Lint Packages
+      - name: Lint packages
         run: npx nx affected --target=lint
-      - name: Nx Integrity Check
+      - name: Nx integrity check
         run: npx nx workspace-lint
       - name: Set up xvfb for Cypress
         run: |
           Xvfb -screen 0 1024x768x24 :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
-      - name: Unit Tests
+      - name: Unit tests
         run: npx nx affected --target=test
-      - name: End to End Tests
+      - name: End to end tests
         run: npx nx affected --target e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
       - name: Cache Cypress binary
         uses: actions/cache@v3
         with:
           path: ~/.cache/Cypress
-          key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}
       - name: Install dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  NODE_VERSION: 16
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -29,7 +32,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
       - name: Update package-lock.json
         run: npm install --no-audit --no-fund --ignore-scripts --package-lock-only
       - name: Merge changes with last commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -13083,10 +13083,12 @@
       }
     },
     "packages/design-system/tokens": {
+      "name": "@eternagame/design-system-tokens",
       "version": "1.0.0-dev",
       "license": "SEE LICENSE IN LICENSE"
     },
     "packages/design-system/vue": {
+      "name": "@eternagame/design-system-vue",
       "version": "1.0.0-dev",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -13104,6 +13106,7 @@
       }
     },
     "packages/frontend/web": {
+      "name": "@eternagame/frontend-web",
       "version": "1.0.0-dev",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {


### PR DESCRIPTION
The node version was not being pulled from the correct variable and the cypress path had a duplicate "cypress" literal