### PR TITLE
feat(design-system): Storybook-style Cypress component tests

### DIFF
--- a/packages/design-system/vue/cypress/support/ActionBar.vue
+++ b/packages/design-system/vue/cypress/support/ActionBar.vue
@@ -1,0 +1,47 @@
+<template>
+  <header class="actionBar">
+    <div class="actionBar-themeSelect">
+      <span>Theme: </span>
+      <select
+        id="themeSwitcher"
+        name="themeSwitcher"
+        @:change="changeTheme"
+      >
+        <option value="dark">
+          Dark
+        </option>
+        <option value="light">
+          Light
+        </option>
+      </select>
+    </div>
+  </header>
+  <main>
+    <slot />
+  </main>
+</template>
+
+<script setup lang="ts">
+function changeTheme(event: Event) {
+  const theme = (event.target as HTMLInputElement).value;
+  document.querySelector('html')?.setAttribute('class', theme);
+}
+</script>
+
+<style>
+  .actionBar {
+    width: 100%;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    background-color: #FFFFFF;
+  }
+
+  .actionBar-themeSelect {
+    align-self: flex-end;
+  }
+
+  select {
+    border: none;
+  }
+</style>

--- a/packages/design-system/vue/cypress/support/ActionBar.vue
+++ b/packages/design-system/vue/cypress/support/ActionBar.vue
@@ -1,11 +1,11 @@
 <template>
   <header class="actionBar">
     <div class="actionBar-themeSelect">
-      <span>Theme: </span>
+      <label for="themeSwitcher">Theme: </label>
       <select
         id="themeSwitcher"
         name="themeSwitcher"
-        @:change="changeTheme"
+        @change="changeTheme"
       >
         <option value="dark">
           Dark
@@ -26,6 +26,8 @@ function changeTheme(event: Event) {
   const theme = (event.target as HTMLInputElement).value;
   document.querySelector('html')?.setAttribute('class', theme);
 }
+// Initialize page with default theme
+document.querySelector('html')?.setAttribute('class', 'dark');
 </script>
 
 <style>

--- a/packages/design-system/vue/cypress/support/component-index.html
+++ b/packages/design-system/vue/cypress/support/component-index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html class="dark">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Components App</title>
-
+  <link rel="stylesheet" href="/__cypress/src/src/assets/style.css">
 </head>
 <body>
   <div data-cy-root></div>

--- a/packages/design-system/vue/cypress/support/component-index.html
+++ b/packages/design-system/vue/cypress/support/component-index.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<html class="dark">
+<html>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Components App</title>
-  <link rel="stylesheet" href="/__cypress/src/src/assets/style.css">
 </head>
 <body>
   <div data-cy-root></div>

--- a/packages/design-system/vue/cypress/support/component.ts
+++ b/packages/design-system/vue/cypress/support/component.ts
@@ -25,6 +25,8 @@ import '@/assets/style.css';
 // eslint-plugin-import has a false positive here
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount } from 'cypress/vue';
+import { h } from 'vue';
+import ActionBar from './ActionBar.vue';
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.
@@ -39,7 +41,12 @@ declare global {
   }
 }
 
-Cypress.Commands.add('mount', mount);
+// Use this to mount without ActionBar wrapper component
+// Cypress.Commands.add('mount', mount);
+
+// Augment mount command with an ActionBar wrapper component
+// The ActionBar is where we place app-level settings like theme
+Cypress.Commands.add('mount', (component, ...args) => mount(() => h(ActionBar, {}, () => h(component, args[0].props, args[0].slots)), ...args));
 
 // Example use:
 // cy.mount(MyComponent)

--- a/packages/design-system/vue/cypress/support/component.ts
+++ b/packages/design-system/vue/cypress/support/component.ts
@@ -24,19 +24,26 @@ import '@/assets/style.css';
 
 // eslint-plugin-import has a false positive here
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { mount } from 'cypress/vue';
-import { h } from 'vue';
+import { CyMountOptions, mount, VueTestUtils } from 'cypress/vue';
+import { Component, h } from 'vue';
 import ActionBar from './ActionBar.vue';
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.
 // Alternatively, can be defined in cypress/support/component.d.ts
 // with a <reference path="./component" /> at the top of your spec.
+
 /* eslint-disable @typescript-eslint/no-namespace */
 declare global {
   namespace Cypress {
     interface Chainable {
-      mount: typeof mount
+      mount: <Comp extends Component<P>, P = object>(
+        component: Comp,
+        options: CyMountOptions<P>
+      ) => Cypress.Chainable<{
+        wrapper: InstanceType<typeof VueTestUtils.VueWrapper>
+        component: InstanceType<typeof VueTestUtils.VueWrapper>['vm']
+      }>
     }
   }
 }
@@ -46,7 +53,14 @@ declare global {
 
 // Augment mount command with an ActionBar wrapper component
 // The ActionBar is where we place app-level settings like theme
-Cypress.Commands.add('mount', (component, ...args) => mount(() => h(ActionBar, {}, () => h(component, args[0].props, args[0].slots)), ...args));
+Cypress.Commands.add('mount', <Comp extends Component<P>, P = object>(
+  component: Comp,
+  opts: CyMountOptions<P>,
+) => {
+  const originalComponent: Component = () => h(component, opts.props, opts.slots);
+  const wrappedMountFn: Component = () => h(ActionBar, originalComponent);
+  return mount(wrappedMountFn, opts);
+});
 
 // Example use:
-// cy.mount(MyComponent)
+// cy.mount(MyComponent, { props: {...}, })


### PR DESCRIPTION
## Summary
We plan to use Cypress for testing and documenting our component library. Cypress provides similar features as Storybook, and is extensible for future improvements.

## Related Issues
<!--
    If this PR should close an existing issue, please reference it like "Resolves #1234"
    If this PR should not close but is related to an existing issue, please make a note of it like "Related issue: #1234"
-->
